### PR TITLE
[최제원] Sprint3

### DIFF
--- a/css/login.css
+++ b/css/login.css
@@ -13,13 +13,14 @@
 
 html {
   height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
 }
 
 body {
   font-family: "Pretendard-Regular";
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
 }
 
 .login {
@@ -45,7 +46,7 @@ body {
   color: #3692ff;
 }
 
-h1 {
+.logo__link-header {
   font-size: 66px;
   font-weight: 700;
   line-height: 89.56px;
@@ -166,4 +167,55 @@ h1 {
   line-height: 16px;
   font-weight: 500;
   color: #3692ff;
+}
+
+@media screen and (max-width: 767px) {
+  .login {
+    padding: 0 16px;
+    width: 100%;
+    max-width: 100%;
+    margin: 0 auto;
+  }
+
+  .logo__container {
+    width: 100%;
+    height: auto;
+    padding-bottom: 24px;
+  }
+
+  .logo__img {
+    width: 51px;
+    height: auto;
+  }
+
+  .logo__link-header {
+    font-size: 34px;
+    line-height: 44px;
+  }
+
+  .form__container {
+    gap: 16px;
+  }
+
+  .form__group {
+    gap: 8px;
+  }
+
+  .form__group-label {
+    font-size: 14px;
+    line-height: 24px;
+  }
+
+  .login-button {
+    font-size: 20px;
+    line-height: 32px;
+  }
+
+  .social-login__icon {
+    gap: 16px;
+  }
+
+  .sign-up__container {
+    gap: 4x;
+  }
 }

--- a/css/main.css
+++ b/css/main.css
@@ -22,6 +22,7 @@ a {
 .header {
   position: fixed;
   width: 100%;
+  height: 70px;
   top: 0;
 }
 
@@ -31,7 +32,8 @@ a {
   align-items: center;
   box-sizing: border-box;
   margin: 0 auto;
-  padding: 9.5px 400px;
+  padding: 9.5px 0px;
+  max-width: 1120px;
 }
 
 .header__logo {
@@ -71,8 +73,15 @@ a {
 
 .main-banner__container,
 .sub-banner__container {
-  padding: 0 405px;
-  width: 1110px;
+  margin: 0 auto;
+  width: 100%;
+  max-width: 1110px;
+}
+
+.main-banner__img,
+.sub-banner__img {
+  width: 100%;
+  height: auto;
 }
 
 .main-banner__container {
@@ -89,8 +98,8 @@ a {
   padding-bottom: 60px;
 }
 
-h1,
-h2 {
+.main-banner__title,
+.feature-section__content-box__title {
   font-size: 40px;
   font-weight: 700;
   color: #374151;
@@ -99,7 +108,7 @@ h2 {
 }
 
 .main-banner__click-button {
-  width: 100%;
+  width: 357px;
   color: #f9fafb;
   background-color: #3692ff;
   height: 56px;
@@ -113,8 +122,8 @@ h2 {
 }
 
 .feature-section {
-  padding: 138px 466px;
-  width: 988px;
+  padding: 138px 0;
+  width: 100%;
   margin: 0 auto;
 }
 
@@ -125,6 +134,9 @@ h2 {
   padding: 0 23.5px;
   gap: 64px;
   background-color: #fcfcfc;
+  max-width: 100%;
+  width: 988px;
+  margin: 0 auto;
 }
 
 .feature-section__content-box {
@@ -133,7 +145,6 @@ h2 {
   justify-content: center;
   align-items: flex-start;
   gap: 12px;
-  padding-right: 24px;
 }
 
 .feature-section__content-box__label {
@@ -144,7 +155,7 @@ h2 {
 }
 
 .feature-section__content-box__title {
-  padding-bottom: 24px;
+  padding-bottom: 12px;
 }
 
 .feature-section__content-box__description {
@@ -185,6 +196,7 @@ h2 {
   align-items: center;
   margin: 0 auto;
   padding-top: 32.5px;
+  max-width: 100%;
 }
 
 .footer-ul {
@@ -216,4 +228,134 @@ h2 {
 .footer-ul > li:last-child {
   display: flex;
   gap: 12px;
+}
+
+@media screen and (max-width: 1199px) {
+  .header__container {
+    padding: 9.5px 24px;
+  }
+
+  .main-banner__container,
+  .sub-banner__container {
+    flex-direction: column;
+    padding-top: 84px;
+  }
+
+  .main-banner__container {
+    gap: 0px;
+  }
+
+  .main-banner__container > .main-banner__title br {
+    display: none;
+  }
+
+  .main-banner__title {
+    text-align: center;
+  }
+
+  .main-banner__text-container {
+    padding-bottom: 211px;
+    gap: 24px;
+    align-items: center;
+  }
+
+  .feature-section {
+    padding: 24px;
+  }
+
+  .feature-section__container {
+    flex-direction: column;
+    align-items: flex-start;
+    background-color: #ffffff;
+    padding: 0px;
+    gap: 24px;
+  }
+
+  .feature-section__content-box {
+    text-align: left;
+    width: 100%;
+    gap: 16px;
+  }
+
+  .feature-section__content-box__title {
+    padding-bottom: 8px;
+    font-size: 32px;
+  }
+
+  .feature-section__content-box__title > br {
+    display: none;
+  }
+
+  .feature-section__content-box__description {
+    font-size: 18px;
+    line-height: 26px;
+  }
+
+  .feature-section__content-box__description--right {
+    text-align: right;
+  }
+
+  .feature-section__image {
+    width: 100%;
+    height: auto;
+  }
+
+  .feature-section__image-left {
+    order: 0;
+  }
+
+  .sub-banner__container {
+    padding-top: 201px;
+    gap: 217px;
+  }
+
+  .footer-container {
+    width: 536px;
+  }
+}
+
+@media screen and (max-width: 767px) {
+  .header__container {
+    padding: 9.5px 16px;
+  }
+
+  .header__logo-img {
+    display: none;
+  }
+
+  .main-banner__text-container {
+    padding-bottom: 132px;
+  }
+
+  .main-banner__title {
+    font-size: 32px;
+    line-height: 44.8px;
+  }
+
+  .main-banner__click-button {
+    width: 240px;
+    font-size: 18px;
+    line-height: 26px;
+  }
+  .feature-section__content-box {
+    gap: 8px;
+  }
+
+  .feature-section__content-box__label {
+    font-size: 16px;
+  }
+
+  .feature-section__content-box__title {
+    font-size: 24px;
+    line-height: 32px;
+  }
+
+  .feature-section__content-box__description {
+    font-size: 16px;
+  }
+
+  .sub-banner__container {
+    padding-top: 121px;
+    gap: 131px;
+  }
 }

--- a/css/signup.css
+++ b/css/signup.css
@@ -13,13 +13,14 @@
 
 html {
   height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
 }
 
 body {
   font-family: "Pretendard-Regular";
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
 }
 
 .signup {
@@ -171,4 +172,55 @@ h1 {
   line-height: 16px;
   font-weight: 500;
   color: #3692ff;
+}
+
+@media screen and (max-width: 767px) {
+  .signup {
+    padding: 0 16px;
+    width: 100%;
+    max-width: 100%;
+    margin: 0 auto;
+  }
+
+  .logo__container {
+    width: 100%;
+    height: auto;
+    padding-bottom: 24px;
+  }
+
+  .logo__img {
+    width: 51px;
+    height: auto;
+  }
+
+  .logo__link-header {
+    font-size: 34px;
+    line-height: 44px;
+  }
+
+  .form__container {
+    gap: 16px;
+  }
+
+  .form__group {
+    gap: 8px;
+  }
+
+  .form__group-label {
+    font-size: 14px;
+    line-height: 24px;
+  }
+
+  .signup-button {
+    font-size: 20px;
+    line-height: 32px;
+  }
+
+  .social-login__icon {
+    gap: 16px;
+  }
+
+  .login__container {
+    gap: 4x;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
           />
           <span class="header__logo-text">판다마켓</span>
         </a>
-        <a href="/login.html" class="header__login-button">로그인</a>
+        <a href="/login" class="header__login-button">로그인</a>
       </div>
     </header>
     <section class="main-banner">

--- a/index.html
+++ b/index.html
@@ -24,10 +24,17 @@
     <section class="main-banner">
       <div class="main-banner__container">
         <div class="main-banner__text-container">
-          <h1>일상의 모든 물건을<br />거래해 보세요</h1>
+          <h1 class="main-banner__title">
+            일상의 모든 물건을<br />
+            거래해 보세요
+          </h1>
           <a href="/items" class="main-banner__click-button">구경하러 가기</a>
         </div>
-        <img src="/img/Img_home_top.png" alt="홈 페이지 상단 배너 이미지" />
+        <img
+          src="/img/Img_home_top.png"
+          alt="홈 페이지 상단 배너 이미지"
+          class="main-banner__img"
+        />
       </div>
     </section>
     <section class="feature-section">
@@ -40,10 +47,12 @@
         <div class="feature-section__content-box">
           <h3 class="feature-section__content-box__label">Hot item</h3>
           <h2 class="feature-section__content-box__title">
-            인기 상품을<br />확인해 보세요
+            인기 상품을<br />
+            확인해 보세요
           </h2>
           <p class="feature-section__content-box__description">
-            가장 HOT한 중고거래 물품을<br />판다 마켓에서 확인해 보세요
+            가장 HOT한 중고거래 물품을<br />
+            판다 마켓에서 확인해 보세요
           </p>
         </div>
       </div>
@@ -60,10 +69,14 @@
         >
           <h3 class="feature-section__content-box__label">Search</h3>
           <h2 class="feature-section__content-box__title">
-            구매를 원하는<br />상품을 검색하세요
+            구매를 원하는<br />
+            상품을 검색하세요
           </h2>
-          <p class="feature-section__content-box__description">
-            구매하고 싶은 물품은 검색해서<br />쉽게 찾아보세요
+          <p
+            class="feature-section__content-box__description feature-section__content-box__description--right"
+          >
+            구매하고 싶은 물품은 검색해서<br />
+            쉽게 찾아보세요
           </p>
         </div>
       </div>
@@ -78,10 +91,12 @@
         <div class="feature-section__content-box">
           <h3 class="feature-section__content-box__label">Register</h3>
           <h2 class="feature-section__content-box__title">
-            판매를 원하는<br />상품을 등록하세요
+            판매를 원하는<br />
+            상품을 등록하세요
           </h2>
           <p class="feature-section__content-box__description">
-            어떤 물건이든 판매하고 싶은 상품을<br />쉽게 등록하세요
+            어떤 물건이든 판매하고 싶은 상품을<br />
+            쉽게 등록하세요
           </p>
         </div>
       </div>
@@ -89,9 +104,16 @@
     <section class="sub-banner">
       <div class="sub-banner__container">
         <div class="sub-banner__text-container">
-          <h1>믿을 수 있는<br />판다마켓 중고 거래</h1>
+          <h1 class="main-banner__title">
+            믿을 수 있는<br />
+            판다마켓 중고 거래
+          </h1>
         </div>
-        <img src="/img/banner-img.png" alt="서브 배너 이미지" />
+        <img
+          src="/img/banner-img.png"
+          alt="서브 배너 이미지"
+          class="sub-banner__img"
+        />
       </div>
     </section>
     <footer class="footer-section">

--- a/login.html
+++ b/login.html
@@ -13,7 +13,9 @@
         <a href="/" class="logo-img__link">
           <img src="/img/큰판다얼굴.png" alt="판다얼굴" class="logo__img" />
         </a>
-        <a href="/" class="logo__link"><h1>판다마켓</h1></a>
+        <a href="/" class="logo__link"
+          ><h1 class="logo__link-header">판다마켓</h1></a
+        >
       </header>
       <div class="login__container">
         <form action="/login" method="POST" class="form__container">
@@ -66,7 +68,7 @@
         </div>
         <div class="sign-up__container">
           <p>판다마켓이 처음이신가요?</p>
-          <a href="/signup.html" class="sign-up__link">회원가입</a>
+          <a href="/signup" class="sign-up__link">회원가입</a>
         </div>
       </div>
     </section>

--- a/signup.html
+++ b/signup.html
@@ -13,7 +13,9 @@
         <a href="/" class="logo-img__link">
           <img src="/img/큰판다얼굴.png" alt="판다얼굴" class="logo__img" />
         </a>
-        <a href="/" class="logo__link"><h1>판다마켓</h1></a>
+        <a href="/" class="logo__link"
+          ><h1 class="logo__link-header">판다마켓</h1></a
+        >
       </header>
       <div class="signup__container">
         <form action="/signup" method="POST" class="form__container">
@@ -90,7 +92,7 @@
         </div>
         <div class="login__container">
           <p>이미 회원이신가요?</p>
-          <a href="/login.html" class="login__link">로그인</a>
+          <a href="/login" class="login__link">로그인</a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## 요구사항

### 기본

- [ ] 메인 홈페이지에서 Tablet 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [ ] 메인 홈페이지에서 Mobile 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [ ] 로그인, 회원가입 홈페이지에서 Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
- [ ] 로그인, 회원가입 홈페이지에서 Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [ ] 로그인, 회원가입 홈페이지에서 Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.

### 심화

- [x] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 좌측 예시와 같은 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정해 주세요.
- [x] 미리보기에서 제목은 “판다 마켓”, 설명은 “일상의 모든 물건을 거래해보세요”로 설정합니다
- [x] 주소와 이미지는 자유롭게 설정하세요. 

## 주요 변경사항

- a태그의 href 주소에서 .html 삭제
- 반응형 웹 사이트로 만들기 위해 media screen css요소 추가 작업

## 스크린샷

![화면 캡처 2024-11-08 192243](https://github.com/user-attachments/assets/33f4f4eb-48d9-4190-b2d4-b4362694d682)
![화면 캡처 2024-11-08 192228](https://github.com/user-attachments/assets/9d76e5b9-66ca-4ede-9237-4a8ba9b24af0)


## 멘토에게

- footer 반응형에서 tablet > mobile로 넘어갈 때, 위 사진와 같이 footer 목록들이 바뀌어야하는데 어떻게 해야할지 잘 모르겠습니다. flex-wrap 도 사용해봤지만 줄바꿈만 이뤄어질뿐, 원하는 모양대로 나오지 않습니다.
-
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
